### PR TITLE
Trim and lowercase e-mails to conform with Gravatar guidelines

### DIFF
--- a/library.js
+++ b/library.js
@@ -146,7 +146,7 @@ function getGravatarUrl(userEmail, username) {
 
 function sum(email) {
 	var md5sum = crypto.createHash('md5');
-	md5sum.update(String(email));
+	md5sum.update(String(email).toLowerCase());
 	md5sum = md5sum.digest('hex');
 	return md5sum;
 }

--- a/library.js
+++ b/library.js
@@ -146,7 +146,7 @@ function getGravatarUrl(userEmail, username) {
 
 function sum(email) {
 	var md5sum = crypto.createHash('md5');
-	md5sum.update(String(email).toLowerCase());
+	md5sum.update(String(email).trim().toLowerCase());
 	md5sum = md5sum.digest('hex');
 	return md5sum;
 }


### PR DESCRIPTION
https://gravatar.com/site/implement/hash/ says emails should be trimmed and lowercased before calculating hash. On our forums we have a situation where user with uppercase characters in his e-mail complained about Gravatar being missing even though old Forums displayed it. Hence this fix.